### PR TITLE
修正 M3U 格式不正确；优化非内网环境下中国大陆访问节目单的优先级以提高速度

### DIFF
--- a/fetchURLByAndroid720p.js
+++ b/fetchURLByAndroid720p.js
@@ -22,7 +22,7 @@ async function fetchURLByAndroid720p() {
     `<tv generator-info-name="Tak" generator-info-url="https://github.com/develop202/migu_video/">\n`)
 
   // 写入开头
-  appendFile(path, `#EXTM3U x-tvg-url="https://develop202.github.io/migu_video/playback.xml,https://raw.githubusercontent.com/develop202/migu_video/refs/heads/main/playback.xml,https://gh-proxy.com/https://raw.githubusercontent.com/develop202/migu_video/refs/heads/main/playback.xml" catchup="append" catchup-source="&playbackbegin=\${(b)yyyyMMddHHmmss}&playbackend=\${(e)yyyyMMddHHmmss}"\n`)
+  appendFile(path, `#EXTM3U x-tvg-url="https://cdn.jsdelivr.net/gh/develop202/migu_video/playback.xml,https://ghfast.top/raw.githubusercontent.com/develop202/migu_video/refs/heads/main/playback.xml,https://hk.gh-proxy.org/raw.githubusercontent.com/develop202/migu_video/refs/heads/main/playback.xml,https://develop202.github.io/migu_video/playback.xml,https://raw.githubusercontents.com/develop202/migu_video/refs/heads/main/playback.xml" catchup="append" catchup-source="&playbackbegin=\${(b)yyyyMMddHHmmss}&playbackend=\${(e)yyyyMMddHHmmss}"\n`)
 
   // 分类列表
   for (let i = 0; i < datas.length; i++) {
@@ -48,7 +48,7 @@ async function fetchURLByAndroid720p() {
       }
 
       // 写入节目
-      appendFile(path, `#EXTINF:-1 svg-id="${data[j].name}" svg-name="${data[j].name}" tvg-logo="${data[j].pics.highResolutionH}" group-title="${datas[i].name}",${data[j].name}\n${resObj.url}\n`)
+      appendFile(path, `#EXTINF:-1 tvg-id="${data[j].name}" tvg-name="${data[j].name}" tvg-logo="${data[j].pics.highResolutionH}" group-title="${datas[i].name}",${data[j].name}\n${resObj.url}\n`)
       printGreen(`    节目链接更新成功`)
     }
   }


### PR DESCRIPTION
svg-id、svg-name不是合法的用于匹配节目单的关键词。见 https://github.com/kodi-pvr/pvr.iptvsimple?tab=readme-ov-file#m3u-format-elements 。