### PR TITLE
允许 HEAD 请求以提升客户端兼容性

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,6 +58,15 @@ const server = http.createServer(async (req, res) => {
   // printGreen("")
   printMagenta("请求地址：" + url)
 
+  if (method === "HEAD") {
+    res.writeHead(200, {
+      "Content-Type": "application/json;charset=UTF-8",
+    });
+    res.end();
+    loading = false;
+    return;
+  }
+
   if (method != "GET") {
     res.writeHead(200, { 'Content-Type': 'application/json;charset=UTF-8' });
     res.end(JSON.stringify({


### PR DESCRIPTION
### 概述

本 PR 调整了请求方法的限制逻辑，允许 HTTP HEAD 请求通过，而不是统一拒绝所有非 GET 请求。

### 背景

部分客户端（如 IPTV 播放器 APTV，以及 Emby、VLC 等媒体工具）在实际请求资源前，会先发送 HEAD 请求以检查资源可用性。

当前实现中，服务端会拒绝所有非 GET 请求，导致这些客户端在预检阶段即判定资源不可用，从而无法正常发起后续的 GET 请求。

### 修改内容

- 允许 HEAD 请求通过
- 对 HEAD 请求返回标准响应头（不包含响应体）

### 影响范围

- 不影响现有 GET 请求逻辑
- 提升以下场景的兼容性：
  - IPTV 播放器
  - 媒体服务器（如 Emby）
  - 直链检测工具（如 curl -I）
  - 文件服务类应用（如 OpenList）

### 说明

该修改为兼容性优化，改动范围较小，风险较低。

后续如有需要，可进一步完善 HEAD 响应头（如 Content-Type、Accept-Ranges）以增强客户端支持。