### PR TITLE
fix: correct mergeTVCategory logic and enhance network reliability

### DIFF
--- a/utils/fetchList.js
+++ b/utils/fetchList.js
@@ -1,6 +1,8 @@
 import { customMergeCategory, mergeTVCategory } from "../config.js"
 import { fetchUrl } from "./net.js"
 
+const isMergeEnabled = mergeTVCategory !== false && mergeTVCategory !== "false";
+
 function delay(ms) {
   return new Promise(resolve => {
     setTimeout(resolve, ms)
@@ -31,7 +33,7 @@ function mergeCategory(cates) {
     fitArea: ['10000'],
     dataList: []
   }
-  if (mergeTVCategory !== "false") {
+  if (isMergeEnabled) {
 
     for (const cate of cates) {
       if (cate.dataList.length <= 11) {
@@ -92,6 +94,7 @@ function mergeCategory(cates) {
 // 获取分类集合
 async function cateList() {
   const resp = await fetchUrl("https://program-sc.miguvideo.com/live/v2/tv-data/1ff892f2b5ab4a79be6e25b69d2f5d05")
+  if (!resp || !resp.body) return []
   let liveList = resp.body.liveList
   // 热门内容重复
   liveList = liveList.filter(item => {
@@ -115,7 +118,7 @@ async function dataList() {
   for (let cate in cates) {
     try {
       const resp = await fetchUrl("https://program-sc.miguvideo.com/live/v2/tv-data/" + cates[cate].vomsID)
-      cates[cate].dataList = resp.body.dataList
+      cates[cate].dataList = resp && resp.body ? resp.body.dataList : []
     } catch (error) {
       cates[cate].dataList = [];
     }
@@ -124,7 +127,7 @@ async function dataList() {
   // 去除重复节目
   cates = uniqueData(cates)
   // 合并分类
-  if (!mergeTVCategory !== "false") {
+  if (isMergeEnabled) {
     cates = mergeCategory(cates)
   }
   // console.dir(cates, { depth: null })

--- a/utils/net.js
+++ b/utils/net.js
@@ -29,21 +29,18 @@ async function fetchUrl(url, opts = {}, timeout = 6000) {
     controller.abort()
     printRed("请求超时")
   }, timeout);
-  // opts["signal"] = controller.signal
-  const res = await fetch(url, {
-    ...opts,
-    signal: controller.signal
-  })
-    .then(r => {
-      clearTimeout(timeoutId);
-      return r.json()
-    })
-    .catch(err => {
-      console.log(err)
-      clearTimeout(timeoutId);
-    })
-
-  return res
+  try {
+    const res = await fetch(url, {
+      ...opts,
+      signal: controller.signal
+    });
+    clearTimeout(timeoutId);
+    return await res.json();
+  } catch (err) {
+    console.error("请求失败:", err);
+    clearTimeout(timeoutId);
+    return null;
+  }
 }
 
 export {


### PR DESCRIPTION
### Summary of changes
1. Fixed a logical error in the TV category merging configuration, where the merging logic was unconditionally enabled regardless of the configuration value.
2. Enhanced the network request utility (`fetchUrl`) to properly handle failures and return a explicit `null` value, preventing runtime `TypeError` issues when external services are unreachable or return invalid responses.

### Rationale
- The original conditional check `!mergeTVCategory !== "false"` was logically flawed and always evaluated to `true`, preventing users from disabling category merging.
- The `fetchUrl` function returned `undefined` implicitly upon failure, causing downstream modules to attempt property access on `undefined`, which led to application crashes.

### Technical Impact Analysis
- Configuration behavior is now predictable and strictly respects user settings.
- Improved application robustness and stability under network instability or service outages.